### PR TITLE
Set blocking on stdout

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ var xml2js = require('xml2js');
 stdin.resume();
 stdin.setEncoding('utf8');
 
+stdout._handle.setBlocking(true);
+
 stdin.on('data', function (chunk) {
   content += chunk;
 });


### PR DESCRIPTION
Set blocking on stdout so it will flush all data when writing to a pipe.  Currently, large JSON results piped to x2j can result in an output buffer larger than 64k, and the remainder does not get flushed when the process exits.  This causes a problem where piping the output of this command for large files currently results in truncated output.  See also https://github.com/nodejs/node/issues/6297 for notes on the process exit and stdout buffer flushing.